### PR TITLE
fix: not found receipt link

### DIFF
--- a/nau_extensions/financial_manager.py
+++ b/nau_extensions/financial_manager.py
@@ -182,8 +182,8 @@ def get_receipt_link(order):
         transaction_id = order.basket.order_number
         receipt_link_url = _get_financial_manager_setting(site, "receipt-link-url")
         if not receipt_link_url.endswith('/'):
-            receipt_link_url += "/"
-        receipt_link_url += transaction_id
+            receipt_link_url += '/'
+        receipt_link_url += transaction_id + '/'
         token = _get_financial_manager_setting(site, "token")
         try:
             response = requests.post(

--- a/nau_extensions/financial_manager.py
+++ b/nau_extensions/financial_manager.py
@@ -186,6 +186,7 @@ def get_receipt_link(order):
         receipt_link_url += transaction_id + '/'
         token = _get_financial_manager_setting(site, "token")
         try:
+            logger.info("Get receipt link for transaction id [%s]", transaction_id)
             response = requests.post(
                 receipt_link_url,
                 headers={"Authorization": token},
@@ -193,9 +194,10 @@ def get_receipt_link(order):
             )
         except Exception as e:  # pylint: disable=broad-except
             logger.exception("Error can't get receipt link for transaction_id [%s] error: [%s]", transaction_id, e)
+            return None
         finally:
-            content = response.content()
-            logger.info("Get receipt link status: [%d] response: [%s]", response.status_code, content)
+            logger.info("Received the receipt link status_code: [%d]")
         if response.status_code == 200:
-            return content
+            logger.info("Received the receipt link content: [%s]", response.content)
+            return response.content
     return None

--- a/nau_extensions/tests/factories.py
+++ b/nau_extensions/tests/factories.py
@@ -47,6 +47,7 @@ class MockResponse:
         """
         return self.json_data
 
+    @property
     def content(self):
         """
         The Json data

--- a/nau_extensions/tests/test_financial_manager.py
+++ b/nau_extensions/tests/test_financial_manager.py
@@ -486,6 +486,6 @@ class FinancialManagerNAUExtensionsTests(TestCase):
         order = create_order(basket=basket)
 
         link = get_receipt_link(order)
-        mock_fm_receipt_link.assert_called_once_with(f"https://finacial-manager.example.com/api/billing/receipt-link/{basket.order_number}", headers={'Authorization': 'a-very-long-token'}, timeout=10)
+        mock_fm_receipt_link.assert_called_once_with(f"https://finacial-manager.example.com/api/billing/receipt-link/{basket.order_number}/", headers={'Authorization': 'a-very-long-token'}, timeout=10)
 
         self.assertEqual(link, "https://example.com/somereceipt.pdf")


### PR DESCRIPTION
fixes fccn/nau-technical#76

refactor: skip redirect when get receipt link  
It was missing a slash character when getting the receipt link.