### PR TITLE
fix: receipt link method

### DIFF
--- a/nau_extensions/financial_manager.py
+++ b/nau_extensions/financial_manager.py
@@ -197,7 +197,7 @@ def get_receipt_link(order):
         token = _get_financial_manager_setting(site, "token")
         try:
             logger.info("Get receipt link for transaction id [%s]", transaction_id)
-            response = requests.post(
+            response = requests.get(
                 receipt_link_url,
                 headers={"Authorization": token},
                 timeout=10,

--- a/nau_extensions/tests/test_financial_manager.py
+++ b/nau_extensions/tests/test_financial_manager.py
@@ -570,7 +570,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
             },
         },
     )
-    @mock.patch.object(requests, "post", return_value=MockResponse(
+    @mock.patch.object(requests, "get", return_value=MockResponse(
         json_data="https://example.com/somereceipt.pdf",
         status_code=200,
     ))
@@ -616,7 +616,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
             },
         },
     )
-    @mock.patch.object(requests, "post", return_value=MockResponse(
+    @mock.patch.object(requests, "get", return_value=MockResponse(
         status_code=404,
     ))
     def test_get_receipt_link_not_found(self, mock_fm_receipt_link):


### PR DESCRIPTION
Fix the HTTP method from POST to GET
on the get receipt link on financial manager.

relates to fccn/nau-technical#25