### PR TITLE
fix: missing locale files on build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include CHANGELOG.rst
 include LICENSE
 include README.rst
 recursive-include nau_extensions *.py *.html *.txt
+recursive-include nau_extensions/locale *.po *.mo


### PR DESCRIPTION
The locale files were missing when installing this package. fccn/nau-technical#102