### PR TITLE
fix: incorrect client name for billing info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,18 @@ jobs:
           path: ecommerce
     
       - name: Use Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
           cache: 'pip' # caching pip dependencies
-      
+
+      - name: Install specific pip version
+        # Requested celery==4.4.7 from https://files.......... (from -r ecommerce/requirements/dev.txt (line 73)) has invalid metadata: Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
+        #     pytz (>dev)
+        #         ~^
+        # Please use pip<24.1 if you need to use this version.
+        run: pip install "pip<24.1"
+
       - name: Install ecommerce pip requirements
         run: pip install -r ecommerce/requirements/dev.txt
 

--- a/nau_extensions/financial_manager.py
+++ b/nau_extensions/financial_manager.py
@@ -53,6 +53,10 @@ def sync_request_data(bti: BasketTransactionIntegration) -> dict:
     bbi = BasketBillingInformation.get_by_basket(basket)
     order = get_order(basket)
 
+    client_name = ' '.join(filter(None, [getattr(bbi, "first_name", None), getattr(bbi, "last_name", None)]))
+    # fall back to the requested user full name, received from LMS.
+    if not client_name:
+        client_name = basket.owner.full_name
     address_line_1 = getattr(bbi, "line1", None)
     line2 = getattr(bbi, "line2", None)
     line3 = getattr(bbi, "line3", None)
@@ -69,7 +73,7 @@ def sync_request_data(bti: BasketTransactionIntegration) -> dict:
     request_data = {
         "transaction_id": basket.order_number,
         "transaction_type": "credit",
-        "client_name": basket.owner.full_name,
+        "client_name": client_name,
         "email": basket.owner.email,
         "address_line_1": address_line_1,
         "address_line_2": address_line_2,

--- a/nau_extensions/financial_manager.py
+++ b/nau_extensions/financial_manager.py
@@ -195,6 +195,7 @@ def get_receipt_link(order):
             receipt_link_url += '/'
         receipt_link_url += transaction_id + '/'
         token = _get_financial_manager_setting(site, "token")
+        response = None
         try:
             logger.info("Get receipt link for transaction id [%s]", transaction_id)
             response = requests.get(
@@ -206,7 +207,7 @@ def get_receipt_link(order):
             logger.exception("Error can't get receipt link for transaction_id [%s] error: [%s]", transaction_id, e)
             return None
         finally:
-            logger.info("Received the receipt link status_code: [%d]")
+            logger.info("Received the receipt link status_code: [%d]", response.status_code if response else None)
         if response.status_code == 200:
             logger.info("Received the receipt link content: [%s]", response.content)
             return response.content

--- a/nau_extensions/tests/test_financial_manager.py
+++ b/nau_extensions/tests/test_financial_manager.py
@@ -42,7 +42,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
         honor_product = course.create_or_update_seat("honor", False, 0)
         verified_product = course.create_or_update_seat("verified", True, 10)
 
-        owner = UserFactory(email="ecommerce@example.com")
+        owner = UserFactory(email="ecommerce@example.com", full_name="Jon Snow")
 
         # create an empty basket so we know what it's inside
         basket = create_basket(owner=owner, empty=True)
@@ -61,6 +61,8 @@ class FinancialManagerNAUExtensionsTests(TestCase):
         country.save()
 
         bbi = BasketBillingInformation()
+        bbi.first_name = "Fundação"
+        bbi.last_name = "Ciência Tecnologia"
         bbi.line1 = "Av. do Brasil n.º 101"
         bbi.line2 = "AA"
         bbi.line3 = "BB CC"
@@ -79,7 +81,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
             {
                 "transaction_id": basket.order_number,
                 "transaction_type": "credit",
-                "client_name": owner.full_name,
+                "client_name": "Fundação Ciência Tecnologia",
                 "email": "ecommerce@example.com",
                 "address_line_1": "Av. do Brasil n.º 101",
                 "address_line_2": "AA, BB CC",
@@ -144,7 +146,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
         honor_product = course.create_or_update_seat("honor", False, 0)
         verified_product = course.create_or_update_seat("verified", True, 10)
 
-        owner = UserFactory(email="ecommerce@example.com")
+        owner = UserFactory(email="ecommerce@example.com", full_name="Jon Snow")
 
         # create an empty basket so we know what it's inside
         basket = create_basket(owner=owner, empty=True)
@@ -181,7 +183,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
             {
                 "transaction_id": basket.order_number,
                 "transaction_type": "credit",
-                "client_name": owner.full_name,
+                "client_name": "Jon Snow",
                 "email": "ecommerce@example.com",
                 "address_line_1": "Av. do Brasil n.º 101",
                 "address_line_2": "AA",


### PR DESCRIPTION
Fix the integration with financial manager, the client name should come from
primary from the custom NAU billing information. And only then use the
name of the user authenticated.

fix: fccn/nau-technical#196