### PR TITLE
fix: product title in EN

### DIFF
--- a/nau_extensions/signals.py
+++ b/nau_extensions/signals.py
@@ -1,10 +1,14 @@
+import re
+
+from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from nau_extensions.financial_manager import \
     send_to_financial_manager_if_enabled
 from nau_extensions.models import BasketTransactionIntegration
-from oscar.core.loading import get_class
+from oscar.core.loading import get_class, get_model
 
 post_checkout = get_class("checkout.signals", "post_checkout")
+Product = get_model('catalogue', 'Product')
 
 
 @receiver(
@@ -23,3 +27,23 @@ def create_and_send_basket_transaction_integration_to_financial_manager(
     bti.save()
     bti.refresh_from_db()
     send_to_financial_manager_if_enabled(bti)
+
+
+@receiver(pre_save, sender=Product)
+def change_product_titles(sender, instance, *_args, **kwargs):
+    """
+    Change Product title that is hardcoded in English.
+    So we just find and replace the English words to Portuguese on the Product title field.
+    Also remove the `verified` word, because on NAU this doesn't make sense.
+    Hardcoded code locations:
+    - https://github.com/fccn/ecommerce/blob/132e45e7af964c9addbe97deae6ab4327caa6cce/ecommerce/courses/models.py#L57
+    - https://github.com/fccn/ecommerce/blob/132e45e7af964c9addbe97deae6ab4327caa6cce/ecommerce/courses/models.py#L295
+    - https://github.com/fccn/ecommerce/blob/132e45e7af964c9addbe97deae6ab4327caa6cce/ecommerce/courses/models.py#L134
+    - https://github.com/fccn/ecommerce/blob/132e45e7af964c9addbe97deae6ab4327caa6cce/ecommerce/courses/models.py#L131
+    """
+    new_title = instance.title
+    new_title = new_title.replace('Seat in', 'Lugar em')
+    new_title = new_title.replace('Enrollment code for verified seat in', 'Código de inscrição para')
+    new_title = new_title.replace('with verified certificate', 'com certificado pago')
+    new_title = new_title.replace('with honor certificate', 'com certificado grátis')
+    instance.title = new_title

--- a/nau_extensions/tests/test_financial_manager.py
+++ b/nau_extensions/tests/test_financial_manager.py
@@ -99,7 +99,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
                     # verified
                     {
                         "unit_price_incl_vat": Decimal("10.00"),
-                        "description": "Seat in edX Demonstration Course with verified certificate",
+                        "description": "Lugar em edX Demonstration Course com certificado pago",
                         'discount_excl_tax': Decimal('0.00'),
                         'discount_incl_tax': Decimal('0.00'),
                         "organization_code": "edX",
@@ -110,7 +110,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
                     # honor
                     {
                         "unit_price_incl_vat": Decimal("0.00"),
-                        "description": "Seat in edX Demonstration Course with honor certificate",
+                        "description": "Lugar em edX Demonstration Course com certificado grátis",
                         'discount_excl_tax': Decimal('0.00'),
                         'discount_incl_tax': Decimal('0.00'),
                         "organization_code": "edX",
@@ -194,7 +194,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
                     # verified
                     {
                         "unit_price_incl_vat": Decimal("10.00"),
-                        "description": "Seat in edX Demonstration Course with verified certificate",
+                        "description": "Lugar em edX Demonstration Course com certificado pago",
                         'discount_excl_tax': Decimal('0.00'),
                         'discount_incl_tax': Decimal('0.00'),
                         "organization_code": "edX",
@@ -205,7 +205,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
                     # honor
                     {
                         "unit_price_incl_vat": Decimal("0.00"),
-                        "description": "Seat in edX Demonstration Course with honor certificate",
+                        "description": "Lugar em edX Demonstration Course com certificado grátis",
                         'discount_excl_tax': Decimal('0.00'),
                         'discount_incl_tax': Decimal('0.00'),
                         "organization_code": "edX",
@@ -289,7 +289,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
                     # verified
                     {
                         "unit_price_incl_vat": Decimal("10.00"),
-                        "description": "Seat in edX Demonstration Course with verified certificate",
+                        "description": "Lugar em edX Demonstration Course com certificado pago",
                         'discount_excl_tax': Decimal('0.00'),
                         'discount_incl_tax': Decimal('0.00'),
                         "organization_code": "edX",
@@ -300,7 +300,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
                     # honor
                     {
                         "unit_price_incl_vat": Decimal("0.00"),
-                        "description": "Seat in edX Demonstration Course with honor certificate",
+                        "description": "Lugar em edX Demonstration Course com certificado grátis",
                         'discount_excl_tax': Decimal('0.00'),
                         'discount_incl_tax': Decimal('0.00'),
                         "organization_code": "edX",
@@ -370,7 +370,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
                     # verified
                     {
                         "unit_price_incl_vat": Decimal("10.00"),
-                        "description": "Seat in edX Demonstration Course with verified certificate",
+                        "description": "Lugar em edX Demonstration Course com certificado pago",
                         "discount_excl_tax": Decimal("0.00"),
                         "discount_incl_tax": Decimal("0.00"),
                         "organization_code": "edX",
@@ -381,7 +381,7 @@ class FinancialManagerNAUExtensionsTests(TestCase):
                     # honor
                     {
                         "unit_price_incl_vat": Decimal("0.00"),
-                        "description": "Seat in edX Demonstration Course with honor certificate",
+                        "description": "Lugar em edX Demonstration Course com certificado grátis",
                         "discount_excl_tax": Decimal("0.00"),
                         "discount_incl_tax": Decimal("0.00"),
                         "organization_code": "edX",

--- a/nau_extensions/tests/test_signals.py
+++ b/nau_extensions/tests/test_signals.py
@@ -1,11 +1,13 @@
-
-import mock
 from nau_extensions.models import BasketTransactionIntegration
+from oscar.core.loading import get_model
 
+from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.test.factories import create_order
-from ecommerce.tests.factories import UserFactory
+from ecommerce.tests.factories import PartnerFactory, UserFactory
 from ecommerce.tests.testcases import TestCase
+
+Product = get_model('catalogue', 'Product')
 
 
 class SignalsNAUExtensionsTests(TestCase):
@@ -22,3 +24,50 @@ class SignalsNAUExtensionsTests(TestCase):
         EdxOrderPlacementMixin().handle_successful_order(order)
         bti = BasketTransactionIntegration.get_by_basket(order.basket)
         self.assertTrue(bti is not None)
+
+    def test_change_product_title_verified(self):
+        """
+        Test change the product hardcoded names in english to portuguese versions for verified course run.
+        """
+        partner = PartnerFactory(short_code="edX")
+        course = CourseFactory(
+            id="course-v1:edX+DemoX+Demo_Course",
+            name="edX Demonstration Course",
+            partner=partner,
+        )
+        product = course.create_or_update_seat("verified", False, 1)
+        product.save()
+        product.refresh_from_db()
+        self.assertEqual(product.title, "Lugar em edX Demonstration Course com certificado pago")
+        self.assertEqual(product.parent.title, "Lugar em edX Demonstration Course")
+
+    def test_change_product_title_honor(self):
+        """
+        Test change the product hardcoded names in english to portuguese versions for `honor` course run.
+        """
+        partner = PartnerFactory(short_code="edX")
+        course = CourseFactory(
+            id="course-v1:edX+DemoX+Demo_Course",
+            name="edX Demonstration Course",
+            partner=partner,
+        )
+        honor_product = course.create_or_update_seat("honor", False, 0)
+        honor_product.save()
+        honor_product.refresh_from_db()
+        self.assertEqual(honor_product.title, "Lugar em edX Demonstration Course com certificado grátis")
+        self.assertEqual(honor_product.parent.title, "Lugar em edX Demonstration Course")
+
+    def test_change_product_title_enrollment_code(self):
+        """
+        Test change the product hardcoded names in english to portuguese versions for verified course run.
+        """
+        partner = PartnerFactory(short_code="edX")
+        course = CourseFactory(
+            id="course-v1:edX+DemoX+Demo_Course",
+            name="edX Demonstration Course",
+            partner=partner,
+        )
+        product = course.create_or_update_seat("verified", False, 1, create_enrollment_code=True)
+        product.save()
+        enrollment_code = course.get_enrollment_code()
+        self.assertEqual(enrollment_code.title, "Código de inscrição para edX Demonstration Course")


### PR DESCRIPTION
The product titles are hardcoded in English.
It was added a pre-save on Products to change the title product's to Portuguese.

related to #30